### PR TITLE
enabling nginx to listen on ipv6

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -24,6 +24,7 @@ define nginx::fpm (
     $log_path = '/var/log/nginx',
     $log_format = undef,
     $port = 80,
+    $enable_ipv6 = false,
     $http_auth = false,
     $server_aliases = [],
     $client_max_body_size = '1m',

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -24,6 +24,7 @@ define nginx::proxy (
   $server_aliases             = [],
   $proxy_host                 = undef,
   $port                       = 80,
+  $enable_ipv6                = false,
   $client_max_body_size       = '1m',
   $ssl_certificate            = undef,
   $ssl_certificate_key        = undef,

--- a/manifests/proxyall.pp
+++ b/manifests/proxyall.pp
@@ -37,6 +37,7 @@
 define nginx::proxyall (
     $port,
     $target,
+    $enable_ipv6 = false,
   ) {
 
   file {

--- a/manifests/redirect.pp
+++ b/manifests/redirect.pp
@@ -54,6 +54,7 @@ define nginx::redirect (
     $target,
     $ip = '*',
     $port = undef,
+    $enable_ipv6 = false,
     $server_aliases = [],
     $ssl_certificate = undef,
     $ssl_certificate_key = undef,

--- a/manifests/redirect.pp
+++ b/manifests/redirect.pp
@@ -52,7 +52,8 @@
 define nginx::redirect (
     $server_name,
     $target,
-    $ip = '*',
+    $ip = '',
+    $ipv6 = '::',
     $port = undef,
     $enable_ipv6 = false,
     $server_aliases = [],

--- a/manifests/static.pp
+++ b/manifests/static.pp
@@ -26,6 +26,7 @@ define nginx::static (
   $server_aliases             = [],
   $port                       = 80,
   $ip                         = '',
+  $enable_ipv6                = false,
   $client_max_body_size       = '1m',
   $ssl_certificate            = undef,
   $ssl_certificate_key        = undef,

--- a/manifests/static.pp
+++ b/manifests/static.pp
@@ -26,6 +26,7 @@ define nginx::static (
   $server_aliases             = [],
   $port                       = 80,
   $ip                         = '',
+  $ipv6                       = '::',
   $enable_ipv6                = false,
   $client_max_body_size       = '1m',
   $ssl_certificate            = undef,

--- a/manifests/unicorn.pp
+++ b/manifests/unicorn.pp
@@ -22,6 +22,7 @@
 define nginx::unicorn (
   $hostname                   = undef,
   $port                       = 80,
+  $enable_ipv6                = false,
   $socket_path                = undef,
   $root_path                  = undef,
   $ssl_certificate            = undef,

--- a/templates/etc/nginx/sites-available/fpm.conf.erb
+++ b/templates/etc/nginx/sites-available/fpm.conf.erb
@@ -8,6 +8,9 @@ map <%= mapping['nginx_var'] %> <%= mapping['mapping'] %> {
 
 server {
   listen <%= @port %>;
+  <% if @enable_ipv6 %>
+  listen [::]:<%= @port %>;
+  <% end %>
   server_name <%= @name %> <% @server_aliases.each do |server_alias| -%><%= server_alias %> <% end -%>;
   server_name_in_redirect off;
   client_max_body_size <%= @client_max_body_size %>;

--- a/templates/etc/nginx/sites-available/httpproxy.conf.erb
+++ b/templates/etc/nginx/sites-available/httpproxy.conf.erb
@@ -1,6 +1,8 @@
 server {
     listen <%= @port %>;
+    <% if @enable_ipv6 %>
     listen [::]:<%= @port %>;
+    <% end %>
     server_name <%= @hostname %> <% @server_aliases.each do |server_alias| -%><%= server_alias %> <% end -%>;
     <% if @ssl == true %>
     ssl_certificate           <%= @ssl_certificate %>;

--- a/templates/etc/nginx/sites-available/httpproxy.conf.erb
+++ b/templates/etc/nginx/sites-available/httpproxy.conf.erb
@@ -1,6 +1,6 @@
 server {
-
-    listen *:<%= @port %>;
+    listen <%= @port %>;
+    listen [::]:<%= @port %>;
     server_name <%= @hostname %> <% @server_aliases.each do |server_alias| -%><%= server_alias %> <% end -%>;
     <% if @ssl == true %>
     ssl_certificate           <%= @ssl_certificate %>;

--- a/templates/etc/nginx/sites-available/proxyall.conf.erb
+++ b/templates/etc/nginx/sites-available/proxyall.conf.erb
@@ -1,6 +1,8 @@
 server {
   listen <%= @port %>;
+  <% if @enable_ipv6 %>
   listen [::]:<%= @port %>;
+  <% end %>
 
   keepalive_timeout    70;
 

--- a/templates/etc/nginx/sites-available/proxyall.conf.erb
+++ b/templates/etc/nginx/sites-available/proxyall.conf.erb
@@ -1,5 +1,6 @@
 server {
-  listen          *:<%= @port %>;
+  listen <%= @port %>;
+  listen [::]:<%= @port %>;
 
   keepalive_timeout    70;
 

--- a/templates/etc/nginx/sites-available/redirect.conf.erb
+++ b/templates/etc/nginx/sites-available/redirect.conf.erb
@@ -1,7 +1,7 @@
 server {
   <% if @enable_ipv6 %>
-  listen <%= @port %>;
-  listen [::]:<%= @port %>;
+  listen <%= @_port %>;
+  listen [::]:<%= @_port %>;
   <% else %>
   listen          <%= @ip %>:<%= @_port %>;
   <% end %>

--- a/templates/etc/nginx/sites-available/redirect.conf.erb
+++ b/templates/etc/nginx/sites-available/redirect.conf.erb
@@ -1,6 +1,10 @@
 server {
+  <% if @enable_ipv6 %>
   listen <%= @port %>;
   listen [::]:<%= @port %>;
+  <% else %>
+  listen          <%= @ip %>:<%= @_port %>;
+  <% end %>
   server_name     <%= @server_name %> <% @server_aliases.each do |server_alias| -%><%= server_alias %> <% end -%>;
 
   <% if @ssl == true %>

--- a/templates/etc/nginx/sites-available/redirect.conf.erb
+++ b/templates/etc/nginx/sites-available/redirect.conf.erb
@@ -1,9 +1,7 @@
 server {
+  listen <%= @ip %>:<%= @_port %>;
   <% if @enable_ipv6 %>
-  listen <%= @_port %>;
-  listen [::]:<%= @_port %>;
-  <% else %>
-  listen          <%= @ip %>:<%= @_port %>;
+  listen [<%= @ipv6 %>]:<%= @_port %>;
   <% end %>
   server_name     <%= @server_name %> <% @server_aliases.each do |server_alias| -%><%= server_alias %> <% end -%>;
 

--- a/templates/etc/nginx/sites-available/redirect.conf.erb
+++ b/templates/etc/nginx/sites-available/redirect.conf.erb
@@ -1,5 +1,6 @@
 server {
-  listen          <%= @ip %>:<%= @_port %>;
+  listen <%= @port %>;
+  listen [::]:<%= @port %>;
   server_name     <%= @server_name %> <% @server_aliases.each do |server_alias| -%><%= server_alias %> <% end -%>;
 
   <% if @ssl == true %>

--- a/templates/etc/nginx/sites-available/static.conf.erb
+++ b/templates/etc/nginx/sites-available/static.conf.erb
@@ -3,7 +3,12 @@
 server {
 
   # Listen
-  listen <%= @ip %>:<%= @port %>;
+  <% if @enable_ipv6 %>
+  listen <%= @port %>;
+  listen [::]:<%= @port %>;
+  <% else %>
+  listen <%= @ip %>:<%= @_port %>;
+  <% end %>
   <% if @ssl == true %>
   ssl on;
   ssl_certificate /etc/nginx/ssl/<%= @ssl_certificate %>;

--- a/templates/etc/nginx/sites-available/static.conf.erb
+++ b/templates/etc/nginx/sites-available/static.conf.erb
@@ -3,11 +3,9 @@
 server {
 
   # Listen
-  <% if @enable_ipv6 %>
-  listen <%= @port %>;
-  listen [::]:<%= @port %>;
-  <% else %>
   listen <%= @ip %>:<%= @port %>;
+  <% if @enable_ipv6 %>
+  listen [<%= @ipv6 %>]:<%= @port %>;
   <% end %>
   <% if @ssl == true %>
   ssl on;

--- a/templates/etc/nginx/sites-available/static.conf.erb
+++ b/templates/etc/nginx/sites-available/static.conf.erb
@@ -7,7 +7,7 @@ server {
   listen <%= @port %>;
   listen [::]:<%= @port %>;
   <% else %>
-  listen <%= @ip %>:<%= @_port %>;
+  listen <%= @ip %>:<%= @port %>;
   <% end %>
   <% if @ssl == true %>
   ssl on;

--- a/templates/etc/nginx/sites-available/unicorn.conf.erb
+++ b/templates/etc/nginx/sites-available/unicorn.conf.erb
@@ -6,7 +6,9 @@ upstream <%= @name %> {
 server {
 
   listen <%= @port %>;
+  <% if @enable_ipv6 %>
   listen [::]:<%= @port %>;
+  <% end %>
   server_name <%= @hostname %>;
   <% if @ssl == true %>
   ssl_certificate           <%= @ssl_certificate %>;

--- a/templates/etc/nginx/sites-available/unicorn.conf.erb
+++ b/templates/etc/nginx/sites-available/unicorn.conf.erb
@@ -6,6 +6,7 @@ upstream <%= @name %> {
 server {
 
   listen <%= @port %>;
+  listen [::]:<%= @port %>;
   server_name <%= @hostname %>;
   <% if @ssl == true %>
   ssl_certificate           <%= @ssl_certificate %>;


### PR DESCRIPTION
Please verify the changes in the config file to enable ipv6 for nginx that currently is not enabled at least on irail.be