### PR TITLE
Enable http_auth on fpm sites (if provided)

### DIFF
--- a/templates/etc/nginx/sites-available/fpm.conf.erb
+++ b/templates/etc/nginx/sites-available/fpm.conf.erb
@@ -42,6 +42,11 @@ server {
 
   index index.html index.php;
 
+  <%- if @http_auth -%>
+  auth_basic           "Restricted access";
+  auth_basic_user_file <%= @http_auth %>;
+  <%- end -%>
+
   location / {
     try_files $uri $uri/ /index.php?$args;
   }

--- a/templates/etc/nginx/sites-available/fpm.conf.erb
+++ b/templates/etc/nginx/sites-available/fpm.conf.erb
@@ -46,7 +46,6 @@ server {
   auth_basic           "Restricted access";
   auth_basic_user_file <%= @http_auth %>;
   <%- end -%>
-
   location / {
     try_files $uri $uri/ /index.php?$args;
   }


### PR DESCRIPTION
Needed for: https://github.com/skyscrapers/puppet/issues/3343

Apparently the `http_auth` parameter was already in the module, but it was not used