### PR TITLE
use a seperate webroot for letsencrypt well-known files

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -53,7 +53,7 @@ define nginx::fpm (
   }
 
   if $manage_letsencrypt_root {
-    $letsencrypt_root = "/var/www/letsencrypt/${name}"
+    $letsencrypt_root = "/var/www/letsencrypt-${name}"
     file {
       $letsencrypt_root:
         ensure => directory,

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -39,6 +39,7 @@ define nginx::fpm (
     $proxy_websocket_match = undef,
     $proxy_websocket_upstream = undef,
     $etag = false,
+    $manage_letsencrypt_root = false,
   ){
 
   if ! defined(Class['nginx']) {
@@ -49,6 +50,17 @@ define nginx::fpm (
     $ssl = false
   } else {
     $ssl = true
+  }
+
+  if $manage_letsencrypt_root {
+    $letsencrypt_root = "/var/www/letsencrypt/${name}"
+    file {
+      $letsencrypt_root:
+        ensure => directory,
+        mode   => '0755',
+        owner  => root,
+        group  => www-data,
+    }
   }
 
   file {

--- a/templates/etc/nginx/sites-available/fpm.conf.erb
+++ b/templates/etc/nginx/sites-available/fpm.conf.erb
@@ -74,7 +74,7 @@ server {
   <%- if @manage_letsencrypt_root -%>
   location /.well-known {
     root <%= @letsencrypt_root %>;
-    try_files $uri $uri/ /index.php?$args;
+    try_files $uri $uri/;
   }
   <%- end -%>
 

--- a/templates/etc/nginx/sites-available/fpm.conf.erb
+++ b/templates/etc/nginx/sites-available/fpm.conf.erb
@@ -71,6 +71,13 @@ server {
      <%= optional_line %>;
   <%- end -%>
 
+  <%- if @manage_letsencrypt_root -%>
+  location /.well-known {
+    root <%= @letsencrypt_root %>;
+    try_files $uri $uri/ /index.php?$args;
+  }
+  <%- end -%>
+
   <%- if @etag -%>
   etag on;
   gzip off;


### PR DESCRIPTION
Allows to set a seperate webroot for letsencrypt files.

this fixes files owned by root in the customer webroot