### PR TITLE
fix parent directory has insecure permissions

### DIFF
--- a/files/etc/logrotate.d/nginx
+++ b/files/etc/logrotate.d/nginx
@@ -18,6 +18,7 @@
 }
 
 /var/www/*/sites/*/logs/*.log {
+        su www-data www-data
 	weekly
 	missingok
 	rotate 52


### PR DESCRIPTION
fix for error: 
`parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.`

The error was seen on web02.irail.skyscrape.rs
Issue: https://github.com/skyscrapers/puppet/issues/3777

It could be failing in other servers as well, in any case if we set permissions on logs to www-data as owner then it's safe to let it do the rotation as well 

Change is tested locally on web02.irail.skyscrape.rs