### PR TITLE
fixing .well-known for single-page template

### DIFF
--- a/templates/etc/nginx/sites-available/singlepage.conf.erb
+++ b/templates/etc/nginx/sites-available/singlepage.conf.erb
@@ -45,6 +45,13 @@ server {
   auth_basic_user_file <%= @http_auth %>;
   <%- end -%>
 
+  <%- if @manage_letsencrypt_root -%>
+  location ^~ /.well-known {
+    root <%= @letsencrypt_root %>;
+    try_files $uri $uri/ =404;
+  }
+  <%- end -%>
+
   # Block access to "hidden" files and directories whose names begin with a
   # period. This includes directories used by version control systems such
   # as Subversion or Git to store control files.
@@ -60,12 +67,6 @@ server {
      <%= optional_line %>;
   <%- end -%>
 
-  <%- if @manage_letsencrypt_root -%>
-  location /.well-known {
-    root <%= @letsencrypt_root %>;
-    try_files $uri $uri/ =404;
-  }
-  <%- end -%>
 
   <%- if @etag -%>
   etag on;


### PR DESCRIPTION
With the current setup .well-known path will be forbidden due to the `deny all`.

This change should fix it
https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms#location-block-syntax