### PR TITLE
add basic auth option to static sites template

### DIFF
--- a/manifests/static.pp
+++ b/manifests/static.pp
@@ -32,6 +32,7 @@ define nginx::static (
   $ssl_certificate            = undef,
   $ssl_certificate_key        = undef,
   $ssl_dh_param               = undef,
+  $http_auth                  = false,
   ){
 
   if ! defined(Class['nginx']) {

--- a/templates/etc/nginx/sites-available/static.conf.erb
+++ b/templates/etc/nginx/sites-available/static.conf.erb
@@ -34,6 +34,11 @@ server {
 
   index index.html index.htm;
 
+  <%- if @http_auth -%>
+  auth_basic           "Restricted access";
+  auth_basic_user_file <%= @http_auth %>;
+  <%- end -%>
+  
   gzip_vary on;
   gzip_static on;
 


### PR DESCRIPTION
Allow basic auth to be set for static hosts.
Required for: https://github.com/skyscrapers/sweepbright/issues/308