### PR TITLE
Add server tokens for nginx status

### DIFF
--- a/files/etc/nginx/sites-available/status
+++ b/files/etc/nginx/sites-available/status
@@ -2,7 +2,7 @@
 
 server {
 
-	listen	         *:8888 default;
+        listen	         *:8888 default;
         server_tokens    on;
 	
 	location /status {

--- a/files/etc/nginx/sites-available/status
+++ b/files/etc/nginx/sites-available/status
@@ -2,8 +2,8 @@
 
 server {
 
-	listen	      	*:8888 default;
-        server_tokens   on;
+	listen	         *:8888 default;
+        server_tokens    on;
 	
 	location /status {
 		stub_status on;

--- a/files/etc/nginx/sites-available/status
+++ b/files/etc/nginx/sites-available/status
@@ -2,8 +2,9 @@
 
 server {
 
-	listen		*:8888 default;
-
+	listen	      	*:8888 default;
+  server_tokens   on;
+	
 	location /status {
 		stub_status on;
 		access_log   off;

--- a/files/etc/nginx/sites-available/status
+++ b/files/etc/nginx/sites-available/status
@@ -3,7 +3,7 @@
 server {
 
 	listen	      	*:8888 default;
-  server_tokens   on;
+        server_tokens   on;
 	
 	location /status {
 		stub_status on;

--- a/files/etc/nginx/sites-available/status
+++ b/files/etc/nginx/sites-available/status
@@ -2,13 +2,13 @@
 
 server {
 
-        listen	         *:8888 default;
-        server_tokens    on;
-	
-	location /status {
-		stub_status on;
-		access_log   off;
-		allow 127.0.0.1;
-		deny all;
-	}
+  listen	         *:8888 default;
+  server_tokens    on;
+
+  location /status {
+    stub_status on;
+    access_log   off;
+    allow 127.0.0.1;
+    deny all;
+  }
 }


### PR DESCRIPTION
Datadog agent fails to get Nginx version when server token is off, this PR enables it for the scope of nginx status 


Related issue: https://github.com/sweepbright/infrastructure/issues/525